### PR TITLE
Required attribute to xml schema

### DIFF
--- a/src/Command/ResourcesAsXMLSchemaCommand.php
+++ b/src/Command/ResourcesAsXMLSchemaCommand.php
@@ -128,12 +128,22 @@ class ResourcesAsXMLSchemaCommand extends Command
             $size = " size=\"$size\"";
         }
 
+        if( $field->getRequired() )
+        {
+            $required = '';
+        }
+        else
+        {
+            $required = ' required="true"';
+        }
+
         $output->writeln(sprintf(
-            '    <column name="%s" phpName="%s" type="%s"%s />',
+            '    <column name="%s" phpName="%s" type="%s"%s%s />',
             $name,
             $phpName,
             $type,
-            $size
+            $size,
+            $required
         ));
     }
 }

--- a/src/Command/ResourcesAsXMLSchemaCommand.php
+++ b/src/Command/ResourcesAsXMLSchemaCommand.php
@@ -128,6 +128,12 @@ class ResourcesAsXMLSchemaCommand extends Command
             $size = " size=\"$size\"";
         }
 
-        $output->writeln(sprintf('    <column name="%s" phpName="%s" type="%s"%s />', $name, $phpName, $type, $size));
+        $output->writeln(sprintf(
+            '    <column name="%s" phpName="%s" type="%s"%s />',
+            $name,
+            $phpName,
+            $type,
+            $size
+        ));
     }
 }


### PR DESCRIPTION
Add `required="true"` to XML schema for fields that are marked as required in RETS metadata.
